### PR TITLE
Update set_timer patch

### DIFF
--- a/platform_wasm/pygame/timer.py
+++ b/platform_wasm/pygame/timer.py
@@ -56,15 +56,20 @@ https://github.com/pygame-web/pygbag/issues/16
 THREADS = {}
 
 
-def patch_set_timer(arg: Union[int, pygame.event.Event], millis: int, loops: int = 0):
-    """Patches the pygame.time.set_timer function to use gthreads"""
-
+def patch_set_timer(
+        event: Union[int, pygame.event.Event],
+        millis: int,
+        loops: int = 0):
+    """repeatedly create an event on the event queue
+    
+    Patches the pygame.time.set_timer function to use gthreads
+    """
     dlay = float(millis) / 1000
-    if isinstance(arg, pygame.event.Event):
-        event = int(arg)
-        cevent = arg
+    if isinstance(event, pygame.event.Event):
+        event_type = event.type
+        cevent = event
     else:
-        event = int(arg)
+        event_type = int(event)
         cevent = pygame.event.Event(event)
 
     event_loop = asyncio.get_event_loop()
@@ -83,8 +88,8 @@ def patch_set_timer(arg: Union[int, pygame.event.Event], millis: int, loops: int
             await asyncio.sleep(dlay)
             if (
                 event_loop.is_closed()
-                or event not in THREADS
-                or THREADS[event] != thread_uuid
+                or event_type not in THREADS
+                or THREADS[event_type] != thread_uuid
                 or (loops and loop_counter >= loops)
             ):
                 break
@@ -97,12 +102,12 @@ def patch_set_timer(arg: Union[int, pygame.event.Event], millis: int, loops: int
         # stale threads will be terminated
         thread_uuid = uuid.uuid4()
         Thread(target=fire_event, args=[thread_uuid]).start()
-        THREADS[event] = thread_uuid
+        THREADS[event_type] = thread_uuid
 
     else:
         # This cancels the timer for the event
         if event in THREADS:
-            del THREADS[event]
+            del THREADS[event_type]
 
 
 pygame.time.set_timer = patch_set_timer

--- a/platform_wasm/pygame/timer.py
+++ b/platform_wasm/pygame/timer.py
@@ -81,7 +81,12 @@ def patch_set_timer(arg: Union[int, pygame.event.Event], millis: int, loops: int
         loop_counter = 0
         while True:
             await asyncio.sleep(dlay)
-            if event_loop.is_closed() or event not in THREADS or THREADS[event] != thread_uuid or (loops and loop_counter >= loops):
+            if (
+                event_loop.is_closed()
+                or event not in THREADS
+                or THREADS[event] != thread_uuid
+                or (loops and loop_counter >= loops)
+            ):
                 break
 
             pygame.event.post(cevent)


### PR DESCRIPTION
This is a follow up to https://github.com/pygame-web/pygbag/issues/16

## Summary of changes
*  Handles termination of timer event for a event type when  `millis` is `0`
* Implemented `loops` handling
* Duplicated timer handling when `set_timer` is called multiple times

Reference:
https://pyga.me/docs/ref/time.html#pygame.time.set_timer

## Not Implemented
when `event` param is an object
>When this function is called with an Event object, the event(s) received on the event queue will be a shallow copy; the dict attribute of the event object passed as an argument and the dict attributes of the event objects received on timer will be references to the same dict object in memory. Modifications on one dict can affect another, use deepcopy operations on the dict object if you don't want this behaviour. However, calling this function with an integer event type would place event objects on the queue that don't have a common dict reference.